### PR TITLE
MIN-61: add PostgreSQL connection variables to server container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,72 +1,77 @@
-version: "3.9"
+version: '3.9'
 
 services:
-    client:
-        container_name: prakticum-client
-        image: prakticum-client
-        build:
-            context: .
-            dockerfile: Dockerfile.client
-            args:
-              CLIENT_PORT: ${CLIENT_PORT}
-        restart: always
-        ports:
-            - "${CLIENT_PORT}:${CLIENT_PORT}"
-        environment:
-          - PORT=${CLIENT_PORT}
-          - CLIENT_PORT=${CLIENT_PORT}
-          - SERVER_PORT=${SERVER_PORT}
-        networks:
-          - practicum-network
-    server:
-        container_name: prakticum-server
-        image: prackicum-server
-        build:
-            context: .
-            dockerfile: Dockerfile.server
-            args:
-              SERVER_PORT: ${SERVER_PORT}
-        restart: always
-        depends_on:
-          - postgres
-        ports:
-            - "${SERVER_PORT}:${SERVER_PORT}"
-        environment:
-          SERVER_PORT: ${SERVER_PORT}
-        networks:
-          - postgres-network
-          - practicum-network
+  client:
+    container_name: prakticum-client
+    image: prakticum-client
+    build:
+      context: .
+      dockerfile: Dockerfile.client
+      args:
+        CLIENT_PORT: ${CLIENT_PORT}
+    restart: always
+    ports:
+      - '${CLIENT_PORT}:${CLIENT_PORT}'
+    environment:
+      - PORT=${CLIENT_PORT}
+      - CLIENT_PORT=${CLIENT_PORT}
+      - SERVER_PORT=${SERVER_PORT}
+    networks:
+      - practicum-network
+  server:
+    container_name: prakticum-server
+    image: prackicum-server
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+      args:
+        SERVER_PORT: ${SERVER_PORT}
+    restart: always
+    depends_on:
+      - postgres
+    ports:
+      - '${SERVER_PORT}:${SERVER_PORT}'
+    environment:
+      SERVER_PORT: ${SERVER_PORT}
+      NODE_ENV: production
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_PORT: ${POSTGRES_PORT}
+    networks:
+      - postgres-network
+      - practicum-network
 
-        command: ./wait-for.sh postgres:${POSTGRES_PORT} -- node /app/src/index.js
+    command: ./wait-for.sh postgres:${POSTGRES_PORT} -- node /app/src/index.js
 
-    postgres:
-      image: postgres:14
-      ports:
-        - "${POSTGRES_PORT}:${POSTGRES_PORT}"
-      environment:
-        POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-        POSTGRES_USER: ${POSTGRES_USER}
-        POSTGRES_DB: ${POSTGRES_DB}
-      volumes:
-        - ./tmp/pgdata:/var/lib/postgresql/data
-      networks:
-        - postgres-network
-    pgadmin:
-      container_name: pgadmin
-      image: dpage/pgadmin4:4.18
-      restart: always
-      environment:
-        PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
-        PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD}
-        PGADMIN_LISTEN_PORT: ${PGADMIN_LISTEN_PORT}
-      ports:
-        - "${PGADMIN_LISTEN_PORT}:${PGADMIN_LISTEN_PORT}"
-      volumes:
-        - ./tmp/pgadmin-data:/var/lib/pgadmin
-      depends_on:
-        - postgres
-      networks:
-        - postgres-network
+  postgres:
+    image: postgres:14
+    ports:
+      - '${POSTGRES_PORT}:${POSTGRES_PORT}'
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - ./tmp/pgdata:/var/lib/postgresql/data
+    networks:
+      - postgres-network
+  pgadmin:
+    container_name: pgadmin
+    image: dpage/pgadmin4:4.18
+    restart: always
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD}
+      PGADMIN_LISTEN_PORT: ${PGADMIN_LISTEN_PORT}
+    ports:
+      - '${PGADMIN_LISTEN_PORT}:${PGADMIN_LISTEN_PORT}'
+    volumes:
+      - ./tmp/pgadmin-data:/var/lib/pgadmin
+    depends_on:
+      - postgres
+    networks:
+      - postgres-network
 
 networks:
   practicum-network:


### PR DESCRIPTION
### Какую задачу решаем

Docker не передавал автоматически переменные из .env файла в контейнеры. Попробовал явно указать в docker-compose.yml 

```
environment:
      SERVER_PORT: ${SERVER_PORT}
      NODE_ENV: production
      POSTGRES_USER: ${POSTGRES_USER}
      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
      POSTGRES_DB: ${POSTGRES_DB}
      POSTGRES_PORT: ${POSTGRES_PORT}
```

Вроде работает.

Сервер запускается:
```
...
prakticum-server  | Connected to PostgreSQL!
...
prakticum-server  | Server is running on http://localhost:5001
```

Скрин PGAdmin: http://joxi.ru/v299oLBiQqXPg2



### Linear Issue: [MIN-61](https://linear.app/mind-blowing-devs/issue/MIN-61)