### PR TITLE
MIN-63: added CSP headers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   server:
     container_name: prakticum-server
-    image: prackicum-server
+    image: prakticum-server
     build:
       context: .
       dockerfile: Dockerfile.server

--- a/nginx-conf/csp.conf
+++ b/nginx-conf/csp.conf
@@ -1,6 +1,15 @@
 proxy_hide_header X-Powered-By;
 add_header X-Content-Type-Options nosniff;
 
-add_header Strict-Transport-Security max-age=86400
+add_header Strict-Transport-Security max-age=86400;
 
 # other CSP stuff...
+set $CSP_SCRIPT_SRC "'self' 'nonce-$request_id' 'strict-dynamic'";
+
+set $CSP_STYLE_SRC "'self' 'nonce-$request_id' https://fonts.googleapis.com";
+
+set $CSP_FONT_SRC "'self' https://fonts.gstatic.com";
+
+set $CSP_CONNECT_SRC "'self' https://ya-praktikum.tech https://fonts.googleapis.com http://localhost:5001 https://fonts.gstatic.com";
+
+add_header Content-Security-Policy "default-src 'none'; script-src $CSP_SCRIPT_SRC; style-src $CSP_STYLE_SRC; img-src 'self'; font-src $CSP_FONT_SRC; connect-src $CSP_CONNECT_SRC; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'; media-src 'self'; worker-src 'self'; child-src 'self'; frame-ancestors 'none';";

--- a/nginx-conf/nginx.conf
+++ b/nginx-conf/nginx.conf
@@ -17,7 +17,9 @@ http {
         return 301 https://$host$request_uri;
 
         # only for debug, in production insecure requests should be redirected
-        #include /etc/nginx/routes.conf;
+        # CSP headers
+        # include /etc/nginx/csp.conf;
+        # include /etc/nginx/routes.conf;
     }
 
     # SSL server block

--- a/nginx-conf/nginx.conf
+++ b/nginx-conf/nginx.conf
@@ -17,7 +17,8 @@ http {
         return 301 https://$host$request_uri;
 
         # only for debug, in production insecure requests should be redirected
-        # CSP headers
+        # CSP headers 
+        # !!! Attention. For debug you need to disable(comment) setting "Strict-Transport-Security" header in /etc/nginx/csp.conf
         # include /etc/nginx/csp.conf;
         # include /etc/nginx/routes.conf;
     }

--- a/nginx-conf/routes.conf
+++ b/nginx-conf/routes.conf
@@ -5,6 +5,7 @@ location / {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Cache-Control no-cache;
+    proxy_set_header X-Request-ID $request_id;
 
     proxy_pass http://prakticum-client:5000;
 }

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -11,6 +11,6 @@
     <body>
         <!--ssr-initial-state-->
         <div id="root"><!--ssr-outlet--></div>
-        <script type="module" src="/src/main.tsx"></script>
+        <script nonce="**CSP_NONCE**" type="module" src="/src/main.tsx"></script>
     </body>
 </html>

--- a/packages/client/server/index.ts
+++ b/packages/client/server/index.ts
@@ -13,9 +13,7 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 // takes .env from the root when in development environment
-const envConfig = isDev
-  ? { path: path.resolve(__dirname, '../../../.env') }
-  : undefined
+const envConfig = isDev ? { path: path.resolve(__dirname, '../../../.env') } : undefined
 dotenv.config(envConfig)
 
 const port = Number(process.env.CLIENT_PORT) || 5000
@@ -34,13 +32,12 @@ async function createServer() {
     })
     app.use(vite.middlewares)
   } else {
-    app.use(
-      express.static(path.join(clientPath, 'dist/client'), { index: false })
-    )
+    app.use(express.static(path.join(clientPath, 'dist/client'), { index: false }))
   }
 
   app.get(/.*/, async (req, res, next) => {
     const url = req.originalUrl
+    const xRequestId = (req.headers['x-request-id'] || '') as string
 
     try {
       let render: (
@@ -50,31 +47,19 @@ async function createServer() {
 
       if (vite) {
         // Получаем файл client/index.html
-        template = await fs.readFile(
-          path.resolve(clientPath, 'index.html'),
-          'utf-8'
-        )
+        template = await fs.readFile(path.resolve(clientPath, 'index.html'), 'utf-8')
 
         // Применяем встроенные HTML-преобразования vite и плагинов
         template = await vite.transformIndexHtml(url, template)
 
         // Загружаем модуль клиента, он будет рендерить HTML-код
-        render = (
-          await vite.ssrLoadModule(
-            path.join(clientPath, 'src/entry-server.tsx')
-          )
-        ).render
+        render = (await vite.ssrLoadModule(path.join(clientPath, 'src/entry-server.tsx'))).render
       } else {
-        template = await fs.readFile(
-          path.join(clientPath, 'dist/client/index.html'),
-          'utf-8'
-        )
+        template = await fs.readFile(path.join(clientPath, 'dist/client/index.html'), 'utf-8')
 
         // Импортируем этот модуль и вызываем с начальным состоянием
         // entryPath fixes import since we cannot use default ones or __dirname
-        const entryPath = pathToFileURL(
-          path.join(clientPath, 'dist/server/entry-server.js')
-        ).href
+        const entryPath = pathToFileURL(path.join(clientPath, 'dist/server/entry-server.js')).href
         render = (await import(entryPath)).render
       }
 
@@ -89,10 +74,11 @@ async function createServer() {
         )
         .replace(
           `<!--ssr-initial-state-->`,
-          `<script>window.REDUX_INITIAL_STATE = ${serialize(initialState, {
+          `<script nonce="${xRequestId}">window.REDUX_INITIAL_STATE = ${serialize(initialState, {
             isJSON: true,
           })}</script>`
         )
+        .replace(/\*\*CSP_NONCE\*\*/g, xRequestId)
 
       // Завершаем запрос и отдаём HTML-страницу
       res.status(200).set({ 'Content-Type': 'text/html' }).send(html)

--- a/packages/client/src/entry-server.tsx
+++ b/packages/client/src/entry-server.tsx
@@ -42,7 +42,7 @@ export const render = async (req: ExpressRequest) => {
   const html = ReactDOM.renderToString(
     <ReduxProvider store={store}>
       <ThemeProvider>
-        <StaticRouterProvider router={router} context={context} />
+        <StaticRouterProvider router={router} context={context} nonce="**CSP_NONCE**" />
       </ThemeProvider>
     </ReduxProvider>
   )

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
   server: {
     port: Number(process.env.CLIENT_PORT) || 3000,
   },
+  html: {
+    cspNonce: '**CSP_NONCE**',
+  },
   define: {
     __EXTERNAL_SERVER_URL__: JSON.stringify(process.env.EXTERNAL_SERVER_URL),
     __INTERNAL_SERVER_URL__: JSON.stringify(process.env.INTERNAL_SERVER_URL),


### PR DESCRIPTION
### Какую задачу решаем
Добавление CSP заголовков

В nginx через заголовок настраиваются ресурсы, к которым у браузера может быть доступ. Для каждого типа ресурсов задаются свои правила. Для пометки разрешенных инлайновых скриптов пробрасывается id request из nginx. На стороне клиента данный id проставляется в атрибут "nonce". 

### Скриншоты/видяшка (если есть)
![image](https://github.com/user-attachments/assets/a8925568-fbf8-44a5-8d7f-282bd64d14cf)
![image](https://github.com/user-attachments/assets/b2d5ff53-03bf-4dcb-8a48-2454801b9365)



### Linear Issue: [MIN-63](https://linear.app/mind-blowing-devs/issue/MIN-63)